### PR TITLE
Merge from AdAway: Properly close streams

### DIFF
--- a/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
+++ b/libraries/RootCommands/src/main/java/org/sufficientlysecure/rootcommands/Shell.java
@@ -228,9 +228,12 @@ public class Shell implements Closeable {
                 } else if (close) {
                     out.write("\nexit 0\n".getBytes());
                     out.flush();
-                    out.close();
                     Log.d(RootCommands.TAG, "Closing shell");
+                    shellProcess.waitFor();
+                    out.close();
                     return;
+                } else {
+                    Thread.sleep(50);
                 }
             }
         } catch (InterruptedException e) {
@@ -290,6 +293,7 @@ public class Shell implements Closeable {
         }
         Log.d(RootCommands.TAG, "Read all output");
         shellProcess.waitFor();
+        stdOutErr.close();
         destroyShellProcess();
 
         while (commandIndex < commands.size()) {


### PR DESCRIPTION
Close streams after shell process termination. This fixes some
ANRs/crashes while doing root operations (at least on some
ROMs/Superuser solutions). These changes may require testing on other
ROMs/configurations. Changes introduced:
* Wait for shell process exit before closing stdin
* Reduce CPU usage (by 50 ms delays) while waiting for new commands
* After shell process exit close stdout/stderr

The changes are exactly the same as in this commit to RootCommands in AdAway repository:
https://github.com/dschuermann/ad-away/commit/2338b6d5c4f2bbfd66686ba1231bfb39d3d0e3b6